### PR TITLE
Removed black.uribl.com, which is a subset of multi.uribl.com

### DIFF
--- a/check-rbl.pl
+++ b/check-rbl.pl
@@ -99,7 +99,6 @@ my @rbl=(
 	'bl.emailbasura.org',
 	'combined.rbl.msrbl.net',
 	'multi.uribl.com',
-	'black.uribl.com',
 	'cblless.anti-spam.org.cn',
 	'cblplus.anti-spam.org.cn',
 	'blackholes.five-ten-sg.com',


### PR DESCRIPTION
As stated by http://uribl.com/about.shtml,  multi.uribl.com "checks to see if a domain is on any of our lists".  Also, http://uribl.com/refused.shtml states that "you should be using multi.uribl.com for resolution".
